### PR TITLE
Added TTL value for the metrics

### DIFF
--- a/src/main/java/org/kairosdb/plugin/carbon/CarbonMetric.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/CarbonMetric.java
@@ -14,6 +14,7 @@ public class CarbonMetric
 {
 	private String m_name;
 	private ImmutableSortedMap.Builder<String, String> m_tags;
+	private int m_ttl = 0;
 
 	public CarbonMetric(String name)
 	{
@@ -26,6 +27,11 @@ public class CarbonMetric
 		m_tags.put(tag, value);
 	}
 
+	public void setTtl(int ttl)
+	{
+		m_ttl = ttl;
+	}
+
 	public String getName()
 	{
 		return m_name;
@@ -35,4 +41,11 @@ public class CarbonMetric
 	{
 		return m_tags.build();
 	}
+
+	public int getTtl()
+	{
+		return m_ttl;
+	}
+
+
 }

--- a/src/main/java/org/kairosdb/plugin/carbon/CarbonPickleServer.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/CarbonPickleServer.java
@@ -124,7 +124,7 @@ public class CarbonPickleServer extends SimpleChannelUpstreamHandler implements 
 
 				try
 				{
-					m_datastore.putDataPoint(carbonMetric.getName(), carbonMetric.getTags(), dataPoint);
+					m_datastore.putDataPoint(carbonMetric.getName(), carbonMetric.getTags(), dataPoint, carbonMetric.getTtl());
 				}
 				catch (DatastoreException e)
 				{

--- a/src/main/java/org/kairosdb/plugin/carbon/CarbonTextServer.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/CarbonTextServer.java
@@ -126,7 +126,7 @@ public class CarbonTextServer extends SimpleChannelUpstreamHandler implements Ch
 				else
 					dp = m_longDataPointFactory.createDataPoint(timestamp, Long.parseLong(msgArr[1]));
 
-				m_datastore.putDataPoint(carbonMetric.getName(), carbonMetric.getTags(), dp);
+				m_datastore.putDataPoint(carbonMetric.getName(), carbonMetric.getTags(), dp, carbonMetric.getTtl());
 			}
 			catch (Exception e)
 			{

--- a/src/main/java/org/kairosdb/plugin/carbon/TemplatesTagParser.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/TemplatesTagParser.java
@@ -9,14 +9,23 @@ import java.util.Arrays;
 public class TemplatesTagParser implements TagParser
 {
 	public static final String TEMPLATES_LIST_PROP = "kairosdb.carbon.templatestagparser.templates";
+	private static final String METRIC_TTL = "kairosdb.carbon.ttl";
+	private static final String METRIC_INVALID_TTL = "kairosdb.carbon.invalidTtl";
 
 	private String m_templates;
+	private int invalidTtl = 0;
+	private int ttl = 0;
 
 	@Inject
 	public TemplatesTagParser(
-		@Named(TEMPLATES_LIST_PROP)String templates)
+		@Named(TEMPLATES_LIST_PROP)String templates,
+		@Named(METRIC_INVALID_TTL)int invalidTtlValue,
+		@Named(METRIC_TTL)int ttlValue)
 	{
 		m_templates = templates;
+
+		invalidTtl = invalidTtlValue;
+		ttl = ttlValue;
 
 		Templates.parse(m_templates);
 	}
@@ -37,6 +46,7 @@ public class TemplatesTagParser implements TagParser
 				ret = invalidMetric(metricName, "does not match metric name pattern", template);
 			} else {
 				ret = template.addTags(new CarbonMetric(targetMetric), metricName);
+				ret.setTtl(ttl);
 				if (ret == null) {
 					ret = invalidMetric(metricName, "does not match tags pattern", template);
 				}
@@ -51,6 +61,7 @@ public class TemplatesTagParser implements TagParser
 		CarbonMetric ret = new CarbonMetric("invalidMetrics");
 		ret.addTag("metricName", metricName);
 		ret.addTag("cause", cause);
+		ret.setTtl(invalidTtl);
 		return ret;
 	}
 

--- a/src/main/resources/kairos-carbon.properties
+++ b/src/main/resources/kairos-carbon.properties
@@ -24,3 +24,8 @@ kairosdb.carbon.templatestagparser.templates=\
 	^metric.example.static_tags .metric.type.metric* type=static another_tag=static_too;\
 	^metric.example.mix .metric.type.metric* [.,_] type=static;\
 	^metric.example.dropped
+
+# TTL value for the metrics; Set 0 for no TTL
+kairosdb.carbon.ttl=8640000
+# TTL value for the metrics not matching with the regex; Set 0 for no TTL
+kairosdb.carbon.invalidTtl=864000

--- a/src/test/java/org/kairosdb/plugin/carbon/CarbonPickleServerTest.java
+++ b/src/test/java/org/kairosdb/plugin/carbon/CarbonPickleServerTest.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.*;
 public class CarbonPickleServerTest
 {
 	private final static int CARBON_PORT = 2004;
+	private final int ZERO_TTL = 0;
 
 	private KairosDatastore m_datastore;
 	private CarbonPickleServer m_server;
@@ -82,7 +83,7 @@ public class CarbonPickleServerTest
 
 		verify(m_datastore, timeout(5000).times(1))
 				.putDataPoint("test.metric_name", tags,
-						new LongDataPoint(now * 1000, 1234));
+						new LongDataPoint(now * 1000, 1234),ZERO_TTL);
 	}
 
 	@Test
@@ -98,6 +99,6 @@ public class CarbonPickleServerTest
 
 		verify(m_datastore, timeout(5000).times(1))
 				.putDataPoint("test.metric_name", tags,
-						new DoubleDataPoint(now * 1000, 12.34));
+						new DoubleDataPoint(now * 1000, 12.34),ZERO_TTL);
 	}
 }

--- a/src/test/java/org/kairosdb/plugin/carbon/CarbonTextServerTest.java
+++ b/src/test/java/org/kairosdb/plugin/carbon/CarbonTextServerTest.java
@@ -43,6 +43,7 @@ import static org.mockito.Mockito.verify;
 public class CarbonTextServerTest
 {
 	private final static int CARBON_PORT = 2003;
+	private final int ZERO_TTL = 0;
 
 	private KairosDatastore m_datastore;
 	private CarbonTextServer m_server;
@@ -84,7 +85,7 @@ public class CarbonTextServerTest
 
 		verify(m_datastore, timeout(5000).times(1))
 				.putDataPoint("test.metric_name", tags,
-						new LongDataPoint(now * 1000, 1234));
+						new LongDataPoint(now * 1000, 1234), ZERO_TTL);
 	}
 
 	@Test
@@ -100,6 +101,6 @@ public class CarbonTextServerTest
 
 		verify(m_datastore, timeout(5000).times(1))
 				.putDataPoint("test.metric_name", tags,
-						new DoubleDataPoint(now * 1000, 12.34));
+						new DoubleDataPoint(now * 1000, 12.34), ZERO_TTL);
 	}
 }

--- a/src/test/java/org/kairosdb/plugin/carbon/TemplatesTagParserTest.java
+++ b/src/test/java/org/kairosdb/plugin/carbon/TemplatesTagParserTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.verify;
 public class TemplatesTagParserTest
 {
 	private final static int CARBON_PORT = 2003;
+	private final int ZERO_TTL = 0;
 
 	private KairosDatastore m_datastore;
 	private CarbonTextServer m_server;
@@ -49,7 +50,7 @@ public class TemplatesTagParserTest
 			"^test2.metric .metric.host.metric* [.,_];" +
 			"^test3.metric .metric.host.metric* type=static";
 
-		TemplatesTagParser templatesTagParser = new TemplatesTagParser(m_templates);
+		TemplatesTagParser templatesTagParser = new TemplatesTagParser(m_templates, ZERO_TTL, ZERO_TTL);
 
 		m_server = new CarbonTextServer(m_datastore, templatesTagParser, CARBON_PORT);
 		m_server.start();
@@ -77,7 +78,7 @@ public class TemplatesTagParserTest
 
 		verify(m_datastore, timeout(5000).times(1))
 				.putDataPoint("metric.name", tags,
-						new LongDataPoint(now * 1000, 1234));
+						new LongDataPoint(now * 1000, 1234),ZERO_TTL);
 	}
 
 	@Test
@@ -93,7 +94,7 @@ public class TemplatesTagParserTest
 
 		verify(m_datastore, timeout(5000).times(1))
 				.putDataPoint("metric_name", tags,
-						new LongDataPoint(now * 1000, 1234));
+						new LongDataPoint(now * 1000, 1234),ZERO_TTL);
 	}
 
 	@Test
@@ -110,7 +111,7 @@ public class TemplatesTagParserTest
 
 		verify(m_datastore, timeout(5000).times(1))
 				.putDataPoint("metric.name", tags,
-						new LongDataPoint(now * 1000, 1234));
+						new LongDataPoint(now * 1000, 1234),ZERO_TTL);
 	}
 
 	@Test
@@ -127,7 +128,7 @@ public class TemplatesTagParserTest
 
 		verify(m_datastore, timeout(5000).times(1))
 				.putDataPoint("invalidMetrics", tags,
-						new LongDataPoint(now * 1000, 1234));
+						new LongDataPoint(now * 1000, 1234),ZERO_TTL);
 	}
 
 	@Test
@@ -145,6 +146,6 @@ public class TemplatesTagParserTest
 
 		verify(m_datastore, timeout(5000).times(1))
 				.putDataPoint("invalidMetrics", tags,
-						new LongDataPoint(now * 1000, 1234));
+						new LongDataPoint(now * 1000, 1234),ZERO_TTL);
 	}
 }


### PR DESCRIPTION
Separate TTLs can be set for both the valid and invalid metrics, through kairos-cabon.properties
